### PR TITLE
Correct project name in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ShortcutBadger: https://github.com/leolin310148/ShortcutBadger.
 Takes look at ShortcutBadger.
 
 # Install
-```npm install react-native-image-picker@latest --save```
+```npm install react-native-shortcutbadger@latest --save```
 
 1.In your `android/settings.gradle` file, make the following additions:
 ```


### PR DESCRIPTION
It appears that the incorrect name is listed in the install instructions, telling the user to install `react-native-image-picker` rather than `react-native-shortcutbadger`.